### PR TITLE
Make requests asyncronous

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
@@ -1,18 +1,18 @@
 package io.github.hypixel_api_wrapper;
 
-import io.github.hypixel_api_wrapper.http.RequestFactory;
-
+import io.github.hypixel_api_wrapper.wrapper.HypixelAPIDataRetrieval;
 import java.io.IOException;
+import java.util.UUID;
 
 public class HypixelAPI {
-    private final String key;
-    private HypixelAPI(String key) {
-        this.key = key;
+
+    private final HypixelAPIDataRetrieval<?> dataRetriever;
+
+    private HypixelAPI(UUID apiKey) {
+        this.dataRetriever = new HypixelAPIDataRetrieval<>(apiKey);
     }
-    public static HypixelAPI create(String key) {
-        return new HypixelAPI(key);
-    }
-    public static void shutdown() throws IOException {
-        RequestFactory.close();
+
+    public void shutdown() throws IOException {
+        dataRetriever.close();
     }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
@@ -20,15 +20,17 @@ public class RequestFactory {
     private static final BasicResponseHandler handler = new BasicResponseHandler();
 
     public static void start() {
-        if (!client.isRunning()) {
-            client.start();
+        if (client.isRunning()) {
+            throw new IllegalStateException("RequestFactory is already running");
         }
+        client.start();
     }
 
     public static void close() throws IOException {
-        if (client.isRunning()) {
-            client.close();
+        if (!client.isRunning()) {
+            throw new IllegalStateException("RequestFactory is already not running");
         }
+        client.close();
     }
 
     /**
@@ -39,6 +41,10 @@ public class RequestFactory {
      * @return A {@link JSONObject} of the information retrieved.
      */
     public static JSONObject send(String url) {
+        if (!client.isRunning()) {
+            throw new IllegalStateException("RequestFactory is not started");
+        }
+
         try {
             client.start();
             HttpUriRequest request = RequestBuilder.create("GET")

--- a/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
@@ -1,7 +1,9 @@
 package io.github.hypixel_api_wrapper.http;
 
+import io.github.hypixel_api_wrapper.util.Endpoint;
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.URI;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -41,17 +43,17 @@ public class RequestFactory implements Closeable {
      * Sends a request to the Hypixel API. Returns a {@link JSONObject} of the information
      * retrieved.
      *
-     * @param url The API URL of the information that is being retrieved.
+     * @param uri The API URL of the information that is being retrieved.
      * @return A {@link JSONObject} of the information retrieved.
      */
-    public JSONObject send(String url) {
+    public JSONObject send(URI uri) {
         if (!client.isRunning()) {
             client.start();
         }
 
         try {
             HttpUriRequest request = RequestBuilder.create("GET")
-                .setUri(url)
+                .setUri(uri)
                 .addHeader("API-Key", apiKey)
                 .addHeader("content-type", "application/json")
                 .build();
@@ -74,8 +76,7 @@ public class RequestFactory implements Closeable {
      * @param dataLocation The specific piece of data in the JSON file will be retrieved.
      * @return A piece of specified data from the retrieved JSON file.
      */
-    public String getInformation(String endpoint, String dataLocation) {
-        JSONObject object = send(endpoint);
-        return send(endpoint).get(dataLocation).toString();
+    public String getInformation(Endpoint endpoint, String dataLocation) {
+        return send(endpoint.getURI()).get(dataLocation).toString();
     }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/util/Endpoint.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/util/Endpoint.java
@@ -1,7 +1,7 @@
 package io.github.hypixel_api_wrapper.util;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 public enum Endpoint {
     API_KEY("key"),
@@ -32,10 +32,10 @@ public enum Endpoint {
         this.path = "/" + path;
     }
 
-    public URL getURL() {
+    public URI getURI() {
         try {
-            return new URL("https", "api.hypixel.net", path);
-        } catch (MalformedURLException cause) {
+            return new URI("https", "api.hypixel.net", path, null);
+        } catch (URISyntaxException cause) {
             throw new IllegalStateException("Invalid path for " + name() + ": \"" + path + "\"");
         }
     }

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/HypixelAPIDataRetrieval.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/HypixelAPIDataRetrieval.java
@@ -1,10 +1,11 @@
 package io.github.hypixel_api_wrapper.wrapper;
 
 import io.github.hypixel_api_wrapper.http.RequestFactory;
+import io.github.hypixel_api_wrapper.util.Endpoint;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.UUID;
-import org.json.JSONObject;
+import java.util.concurrent.CompletableFuture;
 
 public class HypixelAPIDataRetrieval<E> implements Closeable {
 
@@ -14,9 +15,10 @@ public class HypixelAPIDataRetrieval<E> implements Closeable {
         this.requestFactory = new RequestFactory(apiKey);
     }
 
-    public E getInformation(String endpoint, String dataLocation) {
-        JSONObject object = requestFactory.send(endpoint);
-        return (E) object.get(dataLocation);
+    public CompletableFuture<E> getInformation(Endpoint endpoint, String dataLocation) {
+        return requestFactory
+            .send(endpoint.getURI())
+            .thenApply(body -> (E) body.get(dataLocation));
     }
 
     @Override

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/HypixelAPIDataRetrieval.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/HypixelAPIDataRetrieval.java
@@ -1,11 +1,26 @@
 package io.github.hypixel_api_wrapper.wrapper;
 
 import io.github.hypixel_api_wrapper.http.RequestFactory;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.UUID;
 import org.json.JSONObject;
 
-public class HypixelAPIDataRetrieval <E> {
+public class HypixelAPIDataRetrieval<E> implements Closeable {
+
+    private final RequestFactory requestFactory;
+
+    public HypixelAPIDataRetrieval(UUID apiKey) {
+        this.requestFactory = new RequestFactory(apiKey);
+    }
+
     public E getInformation(String endpoint, String dataLocation) {
-        JSONObject object = RequestFactory.send(endpoint);
+        JSONObject object = requestFactory.send(endpoint);
         return (E) object.get(dataLocation);
+    }
+
+    @Override
+    public void close() throws IOException {
+        requestFactory.close();
     }
 }


### PR DESCRIPTION
Changes:
- `RequestFactory`
  - Major: `send()` now returns a `CompletableFuture<JSONObject>`
    - A cached thread-pool is used to await responses (`Executors.cachedThreadPool()`)
  - Major: No longer a helper class; all methods are now non-static
  - Major: Automatically adds API key to requests (provided via constructor; see previous)
  - Major: Change URL-related parameters from Strings to `URI` (and `Endpoint` when applicable)
  - Minor: Implement `Closeable`, since it already had a `close()` method
  - Minor: Remove `start()` method; the http client is now just started on the first request

- `HypixelAPIDataRetrieval`
  - Major: `getInformation()` now returns a `CompletableFuture<E>`
  - Minor: Add api key parameter to constructor (UUID)
    - Used to create a private instance of `RequestFactory`
  - Minor: Implement `Closeable` to close each instance's RequestFactory

- `HypixelAPI`
  - Minor: Remove unnecessary `create()` method, which just called the constructor
  - Minor: Change api key parameter from String to UUID in the constructor

- `Endpoint`
  - Major: Change `getURL()` to `getURI()`, and change return type from `URL` to `URI`