### PR TITLE
Refactored HypixelRankPlusColor to HypixelColors and added documentation

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/player/HypixelPlayer.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/player/HypixelPlayer.java
@@ -1,6 +1,7 @@
 package io.github.hypixel_api_wrapper.wrapper.player;
 
 import io.github.hypixel_api_wrapper.wrapper.guild.HypixelGuild;
+import io.github.hypixel_api_wrapper.wrapper.util.HypixelColors;
 import java.util.List;
 
 public class HypixelPlayer {
@@ -80,7 +81,7 @@ public class HypixelPlayer {
         throw new UnsupportedOperationException();
     }
 
-    public HypixelRankPlusColor getHypixelRankPlusColor() {
+    public HypixelColors getHypixelRankPlusColor() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/util/HypixelColors.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/util/HypixelColors.java
@@ -1,6 +1,9 @@
-package io.github.hypixel_api_wrapper.wrapper.player;
+package io.github.hypixel_api_wrapper.wrapper.util;
 
-public enum HypixelRankPlusColor {
+/**
+ * An enum of all the colors on the Hypixel Network.
+ */
+public enum HypixelColors {
     RED,
     GOLD,
     GREEN,


### PR DESCRIPTION
The HypixelColors class can be used for more general purposes than just rank plus colors, such as pet colors, guild tag colors and rank colors.