### PR TITLE
Improved caching with validation (time)

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/caching/BasicCachingStrategy.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/caching/BasicCachingStrategy.java
@@ -1,8 +1,10 @@
 package io.github.hypixel_api_wrapper.caching;
 
 import io.github.hypixel_api_wrapper.util.Endpoint;
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
 import org.json.JSONObject;
 
 /**
@@ -10,16 +12,50 @@ import org.json.JSONObject;
  */
 public class BasicCachingStrategy implements CachingStrategy {
 
-    private final Map<Endpoint, JSONObject> cache = new HashMap<>();
+    private final long validCacheTime;
+    private final Clock clock;
+
+    /**
+     * Creates a new {@link BasicCachingStrategy} with a valid cache time of 20s
+     */
+    public BasicCachingStrategy() {
+        this.validCacheTime = 20000;
+        this.clock = Clock.systemUTC();
+    }
+
+    public BasicCachingStrategy(long validCacheTime) {
+        this.validCacheTime = validCacheTime;
+        this.clock = Clock.systemUTC();
+    }
+
+    public BasicCachingStrategy(long validCacheTime, Clock clock) {
+        this.validCacheTime = validCacheTime;
+        this.clock = clock;
+    }
+
+    // The long in the value Pair are the current time ms
+    private final Map<Endpoint, Pair<JSONObject, Long>> cache = new HashMap<>();
 
     @Override
     public void cacheResponse(Endpoint endpoint, JSONObject res) {
-        cache.put(endpoint, res);
+        cache.put(endpoint, Pair.of(res, clock.millis()));
     }
 
     @Override
     public JSONObject getCachedResponse(Endpoint endpoint) {
-        return cache.get(endpoint);
+        Pair<JSONObject, Long> pair = cache.get(endpoint);
+        return pair == null ? null : pair.getLeft();
+    }
+
+    @Override
+    public boolean isCacheValid(Endpoint endpoint) {
+        Pair<JSONObject, Long> pair = cache.get(endpoint);
+        return pair != null && clock.millis() <= pair.getRight() + validCacheTime;
+    }
+
+    @Override
+    public void removeCachedResponse(Endpoint endpoint) {
+        cache.remove(endpoint);
     }
 
     @Override

--- a/src/main/java/io/github/hypixel_api_wrapper/caching/CachingStrategy.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/caching/CachingStrategy.java
@@ -4,7 +4,36 @@ import io.github.hypixel_api_wrapper.util.Endpoint;
 import org.json.JSONObject;
 
 public interface CachingStrategy {
+
+    /**
+     * Saves the response of an endpoint to the cache
+     * @param endpoint the endpoint from where the response came from
+     * @param res the json response
+     */
     void cacheResponse(Endpoint endpoint, JSONObject res);
+
+    /**
+     * Gets a response of the cache
+     * @param endpoint the endpoint where the object came from
+     * @return the response if one for the given endpoint was cached. {@code null} if not
+     */
     JSONObject getCachedResponse(Endpoint endpoint);
+
+    /**
+     * Checks if a cached object is still judged as valid based on the time since caching
+     * @param endpoint the endpoint of the cached response
+     * @return {@code true} if it's still valid {@code false} if not
+     */
+    boolean isCacheValid(Endpoint endpoint);
+
+    /**
+     * Removes a response from the cache if it has been cached before.
+     * @param endpoint the endpoint to the response came from
+     */
+    void removeCachedResponse(Endpoint endpoint);
+
+    /**
+     * Clears the entire cache
+     */
     void clearCache();
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
@@ -68,6 +68,10 @@ public class RequestFactory {
      * This method's use is the exact same as #send, but it adds requests to the cache.
      */
     public static JSONObject getEndpointThroughAPI(Endpoint endpoint) {
+        if (cache.isCacheValid(endpoint)) {
+            return cache.getCachedResponse(endpoint);
+        }
+
         JSONObject res = send(endpoint.toString());
         cache.cacheResponse(endpoint, res);
         return res;

--- a/src/test/java/BasicCachingStrategyTest.java
+++ b/src/test/java/BasicCachingStrategyTest.java
@@ -1,0 +1,80 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.hypixel_api_wrapper.caching.BasicCachingStrategy;
+import io.github.hypixel_api_wrapper.caching.CachingStrategy;
+import io.github.hypixel_api_wrapper.util.Endpoint;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.apache.commons.lang3.tuple.Pair;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class BasicCachingStrategyTest {
+
+    private final long validCacheTime = 10;
+    private final Endpoint endpoint = Endpoint.API_KEY;
+    private final JSONObject object = new JSONObject();
+
+    private MockClock mockClock;
+    private CachingStrategy strategy;
+
+    @BeforeEach
+    void beforeEach() {
+        Pair<MockClock, CachingStrategy> pair = createStrategy();
+        this.mockClock = pair.getLeft();
+        this.strategy = pair.getRight();
+    }
+
+    @Test
+    void testAdd() {
+        JSONObject object = new JSONObject();
+        object.append("foo", 1);
+
+        strategy.cacheResponse(endpoint, object);
+
+        assertEquals(object, strategy.getCachedResponse(endpoint));
+    }
+
+    @Test
+    void testRemoval() {
+        strategy.cacheResponse(endpoint, new JSONObject());
+        strategy.removeCachedResponse(endpoint);
+
+        assertNull(strategy.getCachedResponse(endpoint));
+    }
+
+    // TODO: Maybe add negative time too but that needs discussion whether it's valid or invalid
+
+    @Test
+    void testValidTime() {
+        strategy.cacheResponse(endpoint, object);
+
+        assertTrue(strategy.isCacheValid(endpoint));
+
+        mockClock.plusMillis(validCacheTime);
+
+        assertTrue(strategy.isCacheValid(endpoint));
+    }
+
+    @Test
+    void testInvalidTime() {
+        strategy.cacheResponse(endpoint, object);
+
+        mockClock.plusMillis(validCacheTime + 1);
+
+        assertFalse(strategy.isCacheValid(endpoint));
+    }
+
+    Pair<MockClock, CachingStrategy> createStrategy() {
+        MockClock clock = new MockClock(Instant.ofEpochMilli(0));
+        CachingStrategy cachingStrategy = new BasicCachingStrategy(validCacheTime, clock);
+
+        return Pair.of(clock, cachingStrategy);
+    }
+
+}

--- a/src/test/java/MockClock.java
+++ b/src/test/java/MockClock.java
@@ -1,0 +1,35 @@
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class MockClock extends Clock {
+
+    private Instant time;
+
+    public MockClock(Instant time) {
+        this.time = time;
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return ZoneId.of("UTC");
+    }
+
+    @Override
+    public Clock withZone(ZoneId zoneId) {
+        return new MockClock(Instant.now());
+    }
+
+    @Override
+    public Instant instant() {
+        return time;
+    }
+
+    public void setTime(Instant time) {
+        this.time = time;
+    }
+
+    public void plusMillis(long millis) {
+        setTime(instant().plusMillis(millis));
+    }
+}


### PR DESCRIPTION
Previously the cache was never invalidated. This PR changes that by adding a method to check if the cache is still valid. How that is determined depends on the caching strategy. BasicCachingStrategy for example does that by using a timestamp to invalidate the cache after a certain amount of time.