### PR TITLE
Added private constructor to prevent instantiation

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/util/GuildLevelingUtil.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/util/GuildLevelingUtil.java
@@ -7,6 +7,9 @@ import java.util.List;
 // source code: https://github.com/HypixelDev/PublicAPI/blob/master/hypixel-api-core/src/main/java/net/hypixel/api/util/IGuildLeveling.java
 public class GuildLevelingUtil {
 
+    private GuildLevelingUtil() {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * An unmodifiable list containing the experience needed to get from each level to the next. For


### PR DESCRIPTION
This commit will prevent users from instantiating the GuildLevelingUtil class because it is a utility class. It throws an
UnsupportedOperationException() in case it is instantiated via reflection.