### PR TITLE
Update documentation

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
@@ -27,8 +27,7 @@ public class HypixelAPI {
      * Creates a new instance of the HypixelAPI object
      *
      * @param key             the api key to use for authentication
-     * @param cachingStrategy the caching strategy to use. If null is passed the NoCachingStrategy
-     *                        will be used to disable caching
+     * @param cachingStrategy the caching strategy to use.
      * @return the newly created instance
      */
     public static HypixelAPI create(String key, CachingStrategy cachingStrategy) {


### PR DESCRIPTION
Since the method has been overloaded there was no need for a null check.