### PR TITLE
Updated RequestFactory to be passed into each HypixelObject

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
@@ -3,14 +3,15 @@ package io.github.hypixel_api_wrapper;
 import io.github.hypixel_api_wrapper.caching.CachingStrategy;
 import io.github.hypixel_api_wrapper.caching.NoCachingStrategy;
 import io.github.hypixel_api_wrapper.http.RequestFactory;
+import io.github.hypixel_api_wrapper.wrapper.guild.HypixelGuild;
+import io.github.hypixel_api_wrapper.wrapper.player.HypixelPlayer;
 import java.io.IOException;
 
 public class HypixelAPI {
-
-    private final String key;
+    private static RequestFactory requestFactory;
 
     private HypixelAPI(String key) {
-        this.key = key;
+        requestFactory = new RequestFactory(key);
     }
 
     /**
@@ -27,15 +28,24 @@ public class HypixelAPI {
      * Creates a new instance of the HypixelAPI object
      *
      * @param key             the api key to use for authentication
-     * @param cachingStrategy the caching strategy to use.
+     * @param cachingStrategy the caching strategy to use. If null is passed the NoCachingStrategy
+     *                        will be used to disable caching
      * @return the newly created instance
      */
     public static HypixelAPI create(String key, CachingStrategy cachingStrategy) {
-        RequestFactory.start(cachingStrategy);
+        requestFactory.start(cachingStrategy);
         return new HypixelAPI(key);
     }
 
     public static void shutdown() throws IOException {
-        RequestFactory.close();
+        requestFactory.close();
+    }
+
+    public HypixelPlayer getPlayerByName(String username) {
+        return new HypixelPlayer(username, requestFactory);
+    }
+
+    public HypixelGuild getGuildByName(String name) {
+        return new HypixelGuild(name, requestFactory)
     }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
@@ -6,11 +6,12 @@ import io.github.hypixel_api_wrapper.http.RequestFactory;
 import io.github.hypixel_api_wrapper.wrapper.guild.HypixelGuild;
 import io.github.hypixel_api_wrapper.wrapper.player.HypixelPlayer;
 import java.io.IOException;
+import java.util.UUID;
 
 public class HypixelAPI {
     private static RequestFactory requestFactory;
 
-    private HypixelAPI(String key) {
+    private HypixelAPI(UUID key) {
         requestFactory = new RequestFactory(key);
     }
 

--- a/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
@@ -46,6 +46,6 @@ public class HypixelAPI {
     }
 
     public HypixelGuild getGuildByName(String name) {
-        return new HypixelGuild(name, requestFactory)
+        return new HypixelGuild(name, requestFactory);
     }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
@@ -21,7 +21,7 @@ public class HypixelAPI {
      * @param key the api key to use for authentication
      * @return the newly created instance
      */
-    public static HypixelAPI create(String key) {
+    public static HypixelAPI create(UUID key) {
         return create(key, new NoCachingStrategy());
     }
 
@@ -33,7 +33,7 @@ public class HypixelAPI {
      *                        will be used to disable caching
      * @return the newly created instance
      */
-    public static HypixelAPI create(String key, CachingStrategy cachingStrategy) {
+    public static HypixelAPI create(UUID key, CachingStrategy cachingStrategy) {
         requestFactory.start(cachingStrategy);
         return new HypixelAPI(key);
     }

--- a/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
@@ -55,7 +55,8 @@ public class RequestFactory {
     public JSONObject send(String url) {
         try {
             HttpUriRequest request = RequestBuilder.create("GET")
-                .setUri(url + "/" + apiKey)
+                .setUri(url)
+                .addHeader("API-key", apiKey)
                 .addHeader("content-type", "application/json")
                 .build();
             // TODO implement a CompletableFuture workaround

--- a/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
@@ -3,6 +3,7 @@ package io.github.hypixel_api_wrapper.http;
 import io.github.hypixel_api_wrapper.caching.CachingStrategy;
 import io.github.hypixel_api_wrapper.util.Endpoint;
 import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -24,8 +25,8 @@ public class RequestFactory {
 
     private final String apiKey;
 
-    public RequestFactory(String apiKey) {
-        this.apiKey = apiKey;
+    public RequestFactory(UUID apiKey) {
+        this.apiKey = apiKey.toString();
     }
 
     public void start(CachingStrategy cachingStrategy) {

--- a/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
@@ -55,10 +55,8 @@ public class RequestFactory {
      */
     public JSONObject send(String url) {
         try {
-            HttpUriRequest request = RequestBuilder.create("GET")
-                .setUri(url)
+            HttpUriRequest request = RequestBuilder.get(url)
                 .addHeader("API-key", apiKey)
-                .addHeader("content-type", "application/json")
                 .build();
             // TODO implement a CompletableFuture workaround
             Future<HttpResponse> future = client.execute(request, null);

--- a/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
@@ -22,7 +22,13 @@ public class RequestFactory {
     private static BasicResponseHandler handler;
     private static CachingStrategy cache;
 
-    public static void start(CachingStrategy cachingStrategy) {
+    private final String apiKey;
+
+    public RequestFactory(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public void start(CachingStrategy cachingStrategy) {
         if (!client.isRunning()) {
             client = HttpAsyncClients.createDefault();
             handler = new BasicResponseHandler();
@@ -32,7 +38,7 @@ public class RequestFactory {
         }
     }
 
-    public static void close() throws IOException {
+    public void close() throws IOException {
         if (client.isRunning()) {
             client.close();
             cache.clearCache();
@@ -46,10 +52,10 @@ public class RequestFactory {
      * @param url The API URL of the information that is being retrieved.
      * @return A {@link JSONObject} of the information retrieved.
      */
-    public static JSONObject send(String url) {
+    public JSONObject send(String url) {
         try {
             HttpUriRequest request = RequestBuilder.create("GET")
-                .setUri(url)
+                .setUri(url + "/" + apiKey)
                 .addHeader("content-type", "application/json")
                 .build();
             // TODO implement a CompletableFuture workaround
@@ -67,7 +73,7 @@ public class RequestFactory {
     /**
      * This method's use is the exact same as #send, but it adds requests to the cache.
      */
-    public static JSONObject getEndpointThroughAPI(Endpoint endpoint) {
+    public JSONObject getEndpointThroughAPI(Endpoint endpoint) {
         if (cache.isCacheValid(endpoint)) {
             return cache.getCachedResponse(endpoint);
         }
@@ -84,7 +90,7 @@ public class RequestFactory {
      * @param dataLocation The specific piece of data in the JSON file will be retrieved.
      * @return A piece of specified data from the retrieved JSON file.
      */
-    public static String getInformation(Endpoint endpoint, String dataLocation) {
-        return RequestFactory.send(endpoint.toString()).get(dataLocation).toString();
+    public String getInformation(Endpoint endpoint, String dataLocation) {
+        return send(endpoint.toString()).get(dataLocation).toString();
     }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/guild/HypixelGuild.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/guild/HypixelGuild.java
@@ -1,15 +1,16 @@
 package io.github.hypixel_api_wrapper.wrapper.guild;
 
+import io.github.hypixel_api_wrapper.http.RequestFactory;
 import io.github.hypixel_api_wrapper.wrapper.player.HypixelPlayer;
 import java.util.List;
 
 public class HypixelGuild {
     private String name;
-    private String apiKey;
+    private RequestFactory requestFactory;
 
-    public HypixelGuild(String name, String apiKey) {
+    public HypixelGuild(String name, RequestFactory requestFactory) {
         this.name = name;
-        this.apiKey = apiKey;
+        this.requestFactory = requestFactory;
     }
     public String getName() {
         return name;

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/player/HypixelFriend.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/player/HypixelFriend.java
@@ -1,5 +1,6 @@
 package io.github.hypixel_api_wrapper.wrapper.player;
 
+import io.github.hypixel_api_wrapper.http.RequestFactory;
 import java.time.Instant;
 
 /**
@@ -13,12 +14,12 @@ public class HypixelFriend {
     // when the player and the friend added each other as friends. 
     private final HypixelPlayer player;
     private final HypixelPlayer friend;
-    private final String apiKey;
+    private final RequestFactory requestFactory;
 
-    public HypixelFriend(HypixelPlayer player, HypixelPlayer friend, String apiKey) {
+    public HypixelFriend(HypixelPlayer player, HypixelPlayer friend, RequestFactory requestFactory) {
         this.player = player;
         this.friend = friend;
-        this.apiKey = apiKey;
+        this.requestFactory = requestFactory;
     }
 
     public HypixelPlayer asPlayer() {

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/player/HypixelPlayer.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/player/HypixelPlayer.java
@@ -1,5 +1,6 @@
 package io.github.hypixel_api_wrapper.wrapper.player;
 
+import io.github.hypixel_api_wrapper.http.RequestFactory;
 import io.github.hypixel_api_wrapper.wrapper.guild.HypixelGuild;
 import io.github.hypixel_api_wrapper.wrapper.util.HypixelColors;
 import java.util.Set;
@@ -7,11 +8,11 @@ import java.util.Set;
 public class HypixelPlayer {
 
     private String username;
-    private String apiKey;
+    private RequestFactory requestFactory;
 
-    public HypixelPlayer(String username, String apiKey) {
+    public HypixelPlayer(String username, RequestFactory requestFactory) {
         this.username = username;
-        this.apiKey = apiKey;
+        this.requestFactory = requestFactory;
     }
 
     public String getUsername() {


### PR DESCRIPTION
This commit will allow `RequestFactory` to be passed into different HypixelObjects. This will allow them to retrieve information from the API.

The `RequestFactory` requires an API key an construction. This is so it can append the key to the URL provided by an `Endpoint` being passed in.

The HypixelObjects can now simply request information with the reference to the `RequestFactory` and `Endpoint`.
For example: `requestFactory.getInformation(Endpoint.PLAYER, "stats.bedwars.kills");`