### PR TITLE
Kill/death bedwars enum

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
@@ -11,7 +11,7 @@ public enum BedWarsKillCause {
     ENTITY("entity_attack_"),
     OVERALL("");
 
-    String key;
+    private final String key;
 
     BedWarsKillCause(String key) {
         this.key = key;

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
@@ -9,6 +9,7 @@ public enum BedWarsKillCause {
     FALL("fall_"),
     VOID("void_"),
     ENTITY("entity_attack_"),
+    ENTITY_EXPLOSION("entity_explosion_"),
     OVERALL("");
 
     private final String key;

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
@@ -17,7 +17,7 @@ public enum BedWarsKillCause {
         this.key = key;
     }
 
-    public String getKey() {
+    String getKey() {
         return key;
     }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
@@ -5,12 +5,83 @@ package io.github.hypixel_api_wrapper.wrapper.games.bedwars;
  */
 public enum BedWarsKillCause {
 
+    /**
+     * Normal kill causes.
+     */
+
+    // Kill caused from a projectile.
     PROJECTILE("projectile_"),
+
+    // Kill caused from falling a distance more than 3 blocks.
     FALL("fall_"),
+
+    // Kill caused from falling into the void.
     VOID("void_"),
-    ENTITY("entity_attack_"),
+
+    // Kill caused from an entity attack.
+    ENTITY_ATTACK("entity_attack_"),
+
+    // Kill caused from all kill causes combined.
+    OVERALL("")
+
+
+    /**
+     * Other types of kill causes.
+     */
+
+    // Kill caused from being in the area where a block explodes.
+    BLOCK_EXPLOSION("block_explosion_"),
+
+    // Kill caused when an entity comes in contact with a block such as a Cactus.
+    CONTACT("contact_"),
+
+    // Custom kill.    
+    CUSTOM("custom_"),
+
+    // Kill caused from running out of air while being in water.
+    DROWNING("drowning_"),
+
+    // Kill caused while being in the area where an entity explodes, such as a Creeper.
     ENTITY_EXPLOSION("entity_explosion_"),
-    OVERALL("");
+
+    // Kill caused from being hit by a falling block that deals damage.
+    FALLING_BLOCK("falling_block_"),
+
+    // Kill caused from direct exposure to fire.
+    FIRE("fire_"),
+
+    // Kill caused due to burns caused by fire.
+    FIRE_TICK("fire_tick_"),
+
+    // Kill caused by direct exposure to lava.
+    LAVA("lava_")  ,
+
+    // Kill caused by being struck by lightning.
+    LIGHTNING("lightning_"),
+
+    // Kill caused by being hit by a damage potion or spell.
+    MAGIC("magic_"),
+
+    // Kill caused due to a snowman melting
+    MELTING("melting_"),
+
+    // Kill caused due to an ongoing poison effect.
+    POSION("poison_"),
+
+    // Kill caused by starving due to having an empty hunger bar.
+    STARVATION("starvation_"),
+
+    // Kill caused by being put in a block
+    SUFFOCATION("succination_"),
+
+    // Kill caused by committing suicide using the command "/kill".
+    SUICIDE("suicide_"),
+
+    // Kill caused in retalitation to another attack by the Thorns enchantment.
+    THORNS("thorns_"),
+
+    // Kill caused by the whither potion effect
+    WITHER("wither_");
 
     private final String key;
 
@@ -21,4 +92,4 @@ public enum BedWarsKillCause {
     String getKey() {
         return key;
     }
-}
+    }

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
@@ -1,0 +1,23 @@
+package io.github.hypixel_api_wrapper.wrapper.games.bedwars;
+
+/**
+ * Different types of kills / deaths that are tracked in BedWars.
+ */
+public enum BedWarsKillCause {
+
+    PROJECTILE("projectile_"),
+    FALL("fall_"),
+    VOID("void_"),
+    ENTITY("entity_attack_"),
+    OVERALL("");
+
+
+    String key;
+     BedWarsKillCause(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+         return key;
+    }
+}

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
@@ -12,11 +12,12 @@ public enum BedWarsKillCause {
     OVERALL("");
 
     String key;
-     BedWarsKillCause(String key) {
+
+    BedWarsKillCause(String key) {
         this.key = key;
     }
 
     public String getKey() {
-         return key;
+        return key;
     }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
@@ -22,7 +22,7 @@ public enum BedWarsKillCause {
     ENTITY_ATTACK("entity_attack_"),
 
     // Kill caused from all kill causes combined.
-    OVERALL("")
+    OVERALL(""),
 
 
     /**
@@ -35,7 +35,7 @@ public enum BedWarsKillCause {
     // Kill caused when an entity comes in contact with a block such as a Cactus.
     CONTACT("contact_"),
 
-    // Custom kill.    
+    // Custom kill.
     CUSTOM("custom_"),
 
     // Kill caused from running out of air while being in water.
@@ -92,4 +92,5 @@ public enum BedWarsKillCause {
     String getKey() {
         return key;
     }
+
     }

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/BedWarsKillCause.java
@@ -11,7 +11,6 @@ public enum BedWarsKillCause {
     ENTITY("entity_attack_"),
     OVERALL("");
 
-
     String key;
      BedWarsKillCause(String key) {
         this.key = key;

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/HypixelBedWars.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/HypixelBedWars.java
@@ -31,28 +31,28 @@ public class HypixelBedWars {
         return stats.getInt(stats + "iron_resources_collected_bedwars");
     }
 
-    public int getKills() {
-        throw new UnsupportedOperationException();
+    public int getKills(BedWarsKillCause cause) {
+        return stats.getInt(statsPrefix + cause.getKey() + "kills_bedwars");
     }
 
-    public int getDeaths() {
-        throw new UnsupportedOperationException();
+    public int getDeaths(BedWarsKillCause cause) {
+        return stats.getInt(statsPrefix + cause.getKey() + "deaths_bedwars");
     }
 
-    public double getKillToDeathRatio() {
-        return getKills() / Math.max(getDeaths(), 1);
+    public double getKillToDeathRatio(BedWarsKillCause cause) {
+        return getKills(cause) / Math.max(getDeaths(cause), 1);
     }
 
-    public int getFinalKills() {
-        throw new UnsupportedOperationException();
+    public int getFinalKills(BedWarsKillCause cause) {
+        return stats.getInt(statsPrefix + cause.getKey() + "final_kills_bedwars");
     }
 
-    public int getFinalDeaths() {
-        throw new UnsupportedOperationException();
+    public int getFinalDeaths(BedWarsKillCause cause) {
+        return stats.getInt(statsPrefix + cause.getKey() + "final_deaths_bedwars");
     }
 
-    public double getFinalKillToDeathRatio() {
-        return getFinalKills() / Math.max(getFinalDeaths(), 1);
+    public double getFinalKillToDeathRatio(BedWarsKillCause cause) {
+        return getFinalKills(cause) / Math.max(getFinalDeaths(cause), 1);
     }
 
     public int getWins() {
@@ -69,22 +69,6 @@ public class HypixelBedWars {
 
     public int getBedsBroken() {
         return stats.getInt(statsPrefix + "beds_broken_bedwars");
-    }
-
-    public int getVoidKills() {
-        throw new UnsupportedOperationException();
-    }
-
-    public int getVoidFinalKills() {
-        throw new UnsupportedOperationException();
-    }
-
-    public int getProjectileDeaths() {
-        throw new UnsupportedOperationException();
-    }
-
-    public int getProjectileKills() {
-        throw new UnsupportedOperationException();
     }
 
     public int getItemsPurchasedAmount() {


### PR DESCRIPTION
⚫ Refactor `HypixelBedwars` class to remove a bunch of methods pertaining to kills and deaths.
⚫ Create an enum `BedWarsKillCause` that keeps track of all the different ways a player can be killed and can kill.
⚫ Pass `BedWarsKillCause` into `HypixelBedwars` when trying to retrieve information about kills/deaths. Its selected type will be used for it's JSON key to retrieve the data from the `JSONObject`. 