### PR TITLE
Changed some HTTP client stuff.

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
@@ -35,7 +35,7 @@ public class HypixelAPI {
      * @return the newly created instance
      */
     public static HypixelAPI create(UUID key, CachingStrategy cachingStrategy) {
-        RequestFactory.setCachingStrategy(cachingStrategy);
+        RequestFactory.configure(cachingStrategy);
         return new HypixelAPI(key);
     }
 

--- a/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
@@ -10,10 +10,10 @@ import java.util.UUID;
 
 public class HypixelAPI {
 
-    private static RequestFactory requestFactory;
+    private static UUID key;
 
     private HypixelAPI(UUID key) {
-        requestFactory = new RequestFactory(key);
+        this.key = key;
     }
 
     /**
@@ -35,19 +35,15 @@ public class HypixelAPI {
      * @return the newly created instance
      */
     public static HypixelAPI create(UUID key, CachingStrategy cachingStrategy) {
-        requestFactory.start(cachingStrategy);
+        RequestFactory.setCachingStrategy(cachingStrategy);
         return new HypixelAPI(key);
     }
 
-    public static void shutdown() throws IOException {
-        requestFactory.close();
-    }
-
     public HypixelPlayer getPlayerByName(String username) {
-        return new HypixelPlayer(username, requestFactory);
+        return new HypixelPlayer(username);
     }
 
     public HypixelGuild getGuildByName(String name) {
-        return new HypixelGuild(name, requestFactory);
+        return new HypixelGuild(name);
     }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/Test.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/Test.java
@@ -1,0 +1,8 @@
+package io.github.hypixel_api_wrapper;
+
+public class Test {
+
+    public static void main(String[] args) {
+
+    }
+}

--- a/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
@@ -2,47 +2,26 @@ package io.github.hypixel_api_wrapper.http;
 
 import io.github.hypixel_api_wrapper.http.cache.CachingStrategy;
 import java.io.IOException;
-import java.util.UUID;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
-import org.apache.http.impl.nio.client.HttpAsyncClients;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
 
 public class RequestFactory {
 
-    private static CloseableHttpAsyncClient client;
-    private static BasicResponseHandler handler;
+    private static HttpClient client;
     private static CachingStrategy cache;
 
-    private final String apiKey;
-
-    public RequestFactory(UUID apiKey) {
-        this.apiKey = apiKey.toString();
-    }
-
-    public void start(CachingStrategy cachingStrategy) {
-        if (!client.isRunning()) {
-            client = HttpAsyncClients.createDefault();
-            handler = new BasicResponseHandler();
-            cache = cachingStrategy;
-
-            client.start();
-        }
-    }
-
-    public void close() throws IOException {
-        if (client.isRunning()) {
-            client.close();
-            cache.clearCache();
-        }
+    public static void configure(CachingStrategy cache) {
+        client = HttpClient.newBuilder().build();
+        RequestFactory.cache = cache;
     }
 
     /**
@@ -52,19 +31,16 @@ public class RequestFactory {
      * @param url The API URL of the information that is being retrieved.
      * @return A {@link JSONObject} of the information retrieved.
      */
-    public JSONObject send(String url) {
+    public static CompletableFuture<JSONObject> send(String url) {
         try {
-            HttpUriRequest request = RequestBuilder.get(url)
-                .addHeader("API-key", apiKey)
-                .build();
-            // TODO implement a CompletableFuture workaround
-            Future<HttpResponse> future = client.execute(request, null);
-            HttpResponse response = future.get(500, TimeUnit.MILLISECONDS);
-            JSONObject res = new JSONObject(handler.handleResponse(response));
-            EntityUtils.consume(response.getEntity());
-            return res;
-        } catch (InterruptedException | ExecutionException | IOException | TimeoutException e) {
-            // TODO create own error to handle these exceptions
+            return client.sendAsync(HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofMillis(2000))
+                    .GET()
+                    .build(), HttpResponse.BodyHandlers.ofString())
+                .thenApply(HttpResponse::body)
+                .thenApply(JSONObject::new);
+        } catch(Exception e) { // catching all forms of generic exceptions (unsure if this method throws any (it probably does))
             throw new RuntimeException(e);
         }
     }
@@ -72,12 +48,12 @@ public class RequestFactory {
     /**
      * This method's use is the exact same as #send, but it adds requests to the cache.
      */
-    public JSONObject getEndpointThroughAPI(Endpoint endpoint) {
+    public static CompletableFuture<JSONObject> getEndpointThroughAPI(Endpoint endpoint) {
         if (cache.isCacheValid(endpoint)) {
             return cache.getCachedResponse(endpoint);
         }
 
-        JSONObject res = send(endpoint.toString());
+        CompletableFuture<JSONObject> res = send(endpoint.toString());
         cache.cacheResponse(endpoint, res);
         return res;
     }
@@ -89,7 +65,7 @@ public class RequestFactory {
      * @param dataLocation The specific piece of data in the JSON file will be retrieved.
      * @return A piece of specified data from the retrieved JSON file.
      */
-    public String getInformation(Endpoint endpoint, String dataLocation) {
-        return send(endpoint.toString()).get(dataLocation).toString();
+    public static String getInformation(Endpoint endpoint, String dataLocation) {
+        return send(endpoint.toString()).thenApply(data -> data.get(dataLocation)).toString();
     }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/http/RequestValidator.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/RequestValidator.java
@@ -9,18 +9,15 @@ import io.github.hypixel_api_wrapper.exception.UnknownAPIException;
 import org.json.JSONObject;
 
 public class RequestValidator {
-
+    // prevent instantiation of what is (essentially) a utitlity class
+    private RequestValidator() {}
     public static boolean isValid(JSONObject obj) {
         if (!obj.getBoolean("success")) {
             switch (obj.getString("cause")) {
-                case "Malformed UUID":
-                    throw new MalformedUUIDException("Invalid UUID provided.");
-                case "Invalid API key":
-                    throw new InvalidAPIKeyException("Invalid API key provided");
-                case "Key throttle":
-                    throw new KeyThrottleException("Exceeded 120 requests/minute to the API.");
-                default:
-                    throw new UnknownAPIException("An unknown error has occurred.");
+                case "Malformed UUID" -> throw new MalformedUUIDException("Invalid UUID provided.");
+                case "Invalid API key" -> throw new InvalidAPIKeyException("Invalid API key provided");
+                case "Key throttle" -> throw new KeyThrottleException("Exceeded 120 requests/minute to the API.");
+                default -> throw new UnknownAPIException("An unknown error has occurred.");
             }
         } else if (obj.isNull("player")) {
             throw new PlayerNotFoundException("Player not found.");

--- a/src/main/java/io/github/hypixel_api_wrapper/http/cache/BasicCachingStrategy.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/cache/BasicCachingStrategy.java
@@ -4,6 +4,7 @@ import io.github.hypixel_api_wrapper.http.Endpoint;
 import java.time.Clock;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.tuple.Pair;
 import org.json.JSONObject;
 
@@ -15,7 +16,7 @@ public class BasicCachingStrategy implements CachingStrategy {
     private final long validCacheTime;
     private final Clock clock;
     // The long in the value Pair are the current time ms
-    private final Map<Endpoint, Pair<JSONObject, Long>> cache = new HashMap<>();
+    private final Map<Endpoint, Pair<CompletableFuture<JSONObject>, Long>> cache = new HashMap<>();
 
     /**
      * Creates a new {@link BasicCachingStrategy} with a valid cache time of 20s
@@ -36,19 +37,19 @@ public class BasicCachingStrategy implements CachingStrategy {
     }
 
     @Override
-    public void cacheResponse(Endpoint endpoint, JSONObject res) {
+    public void cacheResponse(Endpoint endpoint, CompletableFuture<JSONObject> res) {
         cache.put(endpoint, Pair.of(res, clock.millis()));
     }
 
     @Override
-    public JSONObject getCachedResponse(Endpoint endpoint) {
-        Pair<JSONObject, Long> pair = cache.get(endpoint);
+    public CompletableFuture<JSONObject> getCachedResponse(Endpoint endpoint) {
+        Pair<CompletableFuture<JSONObject>, Long> pair = cache.get(endpoint);
         return pair == null ? null : pair.getLeft();
     }
 
     @Override
     public boolean isCacheValid(Endpoint endpoint) {
-        Pair<JSONObject, Long> pair = cache.get(endpoint);
+        Pair<CompletableFuture<JSONObject>, Long> pair = cache.get(endpoint);
         return pair != null && clock.millis() <= pair.getRight() + validCacheTime;
     }
 

--- a/src/main/java/io/github/hypixel_api_wrapper/http/cache/CachingStrategy.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/cache/CachingStrategy.java
@@ -1,6 +1,7 @@
 package io.github.hypixel_api_wrapper.http.cache;
 
 import io.github.hypixel_api_wrapper.http.Endpoint;
+import java.util.concurrent.CompletableFuture;
 import org.json.JSONObject;
 
 public interface CachingStrategy {
@@ -11,7 +12,7 @@ public interface CachingStrategy {
      * @param endpoint the endpoint from where the response came from
      * @param res      the json response
      */
-    void cacheResponse(Endpoint endpoint, JSONObject res);
+    void cacheResponse(Endpoint endpoint, CompletableFuture<JSONObject> res);
 
     /**
      * Gets a response of the cache
@@ -19,7 +20,7 @@ public interface CachingStrategy {
      * @param endpoint the endpoint where the object came from
      * @return the response if one for the given endpoint was cached. {@code null} if not
      */
-    JSONObject getCachedResponse(Endpoint endpoint);
+    CompletableFuture<JSONObject> getCachedResponse(Endpoint endpoint);
 
     /**
      * Checks if a cached object is still judged as valid based on the time since caching

--- a/src/main/java/io/github/hypixel_api_wrapper/http/cache/NoCachingStrategy.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/cache/NoCachingStrategy.java
@@ -1,6 +1,7 @@
 package io.github.hypixel_api_wrapper.http.cache;
 
 import io.github.hypixel_api_wrapper.http.Endpoint;
+import java.util.concurrent.CompletableFuture;
 import org.json.JSONObject;
 
 /**
@@ -10,24 +11,29 @@ import org.json.JSONObject;
 public class NoCachingStrategy implements CachingStrategy {
 
     @Override
-    public void cacheResponse(Endpoint endpoint, JSONObject res) {
+    public void cacheResponse(Endpoint endpoint, CompletableFuture<JSONObject> res) {
+        // unsupported
     }
 
     @Override
-    public JSONObject getCachedResponse(Endpoint endpoint) {
+    public CompletableFuture<JSONObject> getCachedResponse(Endpoint endpoint) {
+        // unsupported
         return null;
     }
 
     @Override
     public boolean isCacheValid(Endpoint endpoint) {
+        // unsupported
         return false;
     }
 
     @Override
     public void removeCachedResponse(Endpoint endpoint) {
+        // unsupported
     }
 
     @Override
     public void clearCache() {
+        // unsupported
     }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/guild/HypixelGuild.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/guild/HypixelGuild.java
@@ -7,11 +7,9 @@ import java.util.List;
 public class HypixelGuild {
 
     private final String name;
-    private final RequestFactory requestFactory;
 
-    public HypixelGuild(String name, RequestFactory requestFactory) {
+    public HypixelGuild(String name) {
         this.name = name;
-        this.requestFactory = requestFactory;
     }
 
     public String getName() {

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/player/HypixelPlayer.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/player/HypixelPlayer.java
@@ -11,12 +11,10 @@ import java.util.Set;
 public class HypixelPlayer {
 
     private final String username;
-    private final RequestFactory requestFactory;
     HypixelPlayerGames games;
 
-    public HypixelPlayer(String username, RequestFactory requestFactory) {
+    public HypixelPlayer(String username) {
         this.username = username;
-        this.requestFactory = requestFactory;
     }
 
     public String getUsername() {
@@ -110,6 +108,6 @@ public class HypixelPlayer {
     }
 
     public HypixelPlayerGames getGames() {
-        return Optional.ofNullable(games).orElse(games = new HypixelPlayerGames(requestFactory.getEndpointThroughAPI(Endpoint.PLAYER)));
+        return Optional.ofNullable(games).orElse(games = new HypixelPlayerGames(RequestFactory.getEndpointThroughAPI(Endpoint.PLAYER)));
     }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/player/HypixelPlayerGames.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/player/HypixelPlayerGames.java
@@ -2,6 +2,7 @@ package io.github.hypixel_api_wrapper.wrapper.player;
 
 import io.github.hypixel_api_wrapper.wrapper.games.bedwars.HypixelBedWarsStats;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import org.json.JSONObject;
 
 /**
@@ -14,7 +15,7 @@ public class HypixelPlayerGames {
 
     private HypixelBedWarsStats bedWarsStats;
 
-    public HypixelPlayerGames(JSONObject stats) {
+    public HypixelPlayerGames(CompletableFuture<JSONObject> stats) {
         this.stats = stats;
     }
 

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/player/HypixelPlayerGames.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/player/HypixelPlayerGames.java
@@ -3,6 +3,7 @@ package io.github.hypixel_api_wrapper.wrapper.player;
 import io.github.hypixel_api_wrapper.wrapper.games.bedwars.HypixelBedWarsStats;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import org.json.JSONObject;
 
 /**
@@ -11,7 +12,7 @@ import org.json.JSONObject;
  */
 public class HypixelPlayerGames {
 
-    private final JSONObject stats;
+    private final CompletableFuture<JSONObject> stats;
 
     private HypixelBedWarsStats bedWarsStats;
 
@@ -19,8 +20,8 @@ public class HypixelPlayerGames {
         this.stats = stats;
     }
 
-    public HypixelBedWarsStats getBedWarsStats() {
-        return Optional.ofNullable(bedWarsStats).orElse(bedWarsStats = new HypixelBedWarsStats(stats.getJSONObject("Bedwars")));
+    public HypixelBedWarsStats getBedWarsStats() throws ExecutionException, InterruptedException {
+        return Optional.ofNullable(bedWarsStats).orElse(bedWarsStats = new HypixelBedWarsStats(stats.get().getJSONObject("BedWars")));
     }
 
 }


### PR DESCRIPTION
This commit essentially changes a bunch of things relating to HTTP and caching. A quick summary is listed below.

• Changed all RequestFactory methods to be static.
• Removed #start, #close, and the constructor of RequestFactory class.
• Added #configure method to RequestFactory, used for setting the CachingStrategy.
• Changed #send, #getEndpointThroughAPI, and #getInformation to use CompletableFutures and Java 11's HTTP client.

• Changed all instances of JSONObject in http.cache package to CompletableFuture<JSONObject>.

• Changed some methods of HypixelGuild, HypixelPlayer, and HypixelPlayerGames to use CompletableFutures to integrate with Java 11's HTTP client.

• Changed HypixelAPI's constructor and a few other things.

• Changed RequestValidator to use enhanced switch statements (oooh java 17).