### PR TITLE
Added a `mode` field to `HypixelBedWars`

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/HypixelBedWars.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/HypixelBedWars.java
@@ -6,10 +6,12 @@ public class HypixelBedWars {
 
     private final String statsPrefix ;
     private final JSONObject stats;
+    private final HypixelBedWarsMode mode;
 
     protected HypixelBedWars(JSONObject stats, HypixelBedWarsMode mode) {
-        this.statsPrefix  = mode.getStatsPrefix();
         this.stats = stats;
+        this.mode = mode;
+        this.statsPrefix  = mode.getStatsPrefix();
     }
 
     public int getResourcesCollected() {
@@ -97,5 +99,13 @@ public class HypixelBedWars {
 
     public int getCurrentWinstreak() {
         return stats.getInt(stats + "winstreak");
+    }
+
+    /**
+     * @return The {@link HypixelBedWarsMode} that the statsPrefix
+     * is using. 
+     */
+    public HypixelBedWarsMode getMode() {
+        return mode;
     }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/HypixelBedWars.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/games/bedwars/HypixelBedWars.java
@@ -11,7 +11,7 @@ public class HypixelBedWars {
     protected HypixelBedWars(JSONObject stats, HypixelBedWarsMode mode) {
         this.stats = stats;
         this.mode = mode;
-        this.statsPrefix  = mode.getStatsPrefix();
+        this.statsPrefix = mode.getStatsPrefix();
     }
 
     public int getResourcesCollected() {


### PR DESCRIPTION
This commit will allow the API user to check the mode of the `HypixelBedWars` object they're using. The `mode` field is final, and this is no setter because it is meant to be immutable. In order to get information from a sub-mode a new `HypixelBedWars` would have to be created.