### PR TITLE
Make RequestFactory non-static

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/HypixelAPI.java
@@ -10,10 +10,11 @@ import java.util.UUID;
 
 public class HypixelAPI {
 
-    private static RequestFactory requestFactory;
+    private RequestFactory requestFactory;
 
-    private HypixelAPI(UUID key) {
+    private HypixelAPI(UUID key, CachingStrategy cachingStrategy) {
         requestFactory = new RequestFactory(key);
+        requestFactory.start(cachingStrategy);
     }
 
     /**
@@ -35,11 +36,10 @@ public class HypixelAPI {
      * @return the newly created instance
      */
     public static HypixelAPI create(UUID key, CachingStrategy cachingStrategy) {
-        requestFactory.start(cachingStrategy);
-        return new HypixelAPI(key);
+        return new HypixelAPI(key, cachingStrategy);
     }
 
-    public static void shutdown() throws IOException {
+    public void shutdown() throws IOException {
         requestFactory.close();
     }
 


### PR DESCRIPTION
After multiple previous discussions, we have decided that each `HypixelAPI` `RequestFactory` should not be static. This commit will implement that.

Since it is not static, it begs the question of whether there needs to be a static `Factory` method to initialize the `HypixelAPI`.