### PR TITLE
Change HashMap to EnumMap in caching

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/http/cache/BasicCachingStrategy.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/cache/BasicCachingStrategy.java
@@ -15,7 +15,7 @@ public class BasicCachingStrategy implements CachingStrategy {
     private final long validCacheTime;
     private final Clock clock;
     // The long in the value Pair are the current time ms
-    private final Map<Endpoint, Pair<JSONObject, Long>> cache = new HashMap<>();
+    private final Map<Endpoint, Pair<JSONObject, Long>> cache = new EnumMap<>(Endpoint.class);
 
     /**
      * Creates a new {@link BasicCachingStrategy} with a valid cache time of 20s


### PR DESCRIPTION
Changed HashMap to an EnumMap in BasicCachingStrategy.java.

Unsure of the benefits, but it is recommended to be used in scenarios where the `key` value of the HashMap is meant to be an enum.