### PR TITLE
Change HashMap to EnumMap in caching

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/http/cache/BasicCachingStrategy.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/cache/BasicCachingStrategy.java
@@ -15,7 +15,7 @@ public class BasicCachingStrategy implements CachingStrategy {
     private final long validCacheTime;
     private final Clock clock;
     // The long in the value Pair are the current time ms
-    private final Map<Endpoint, Pair<JSONObject, Long>> cache = new HashMap<>();
+    private final Map<Endpoint, Pair<JSONObject, Long>> cache = new EnumMap<>(Endpoint.class);
 
     /**
      * Creates a new {@link BasicCachingStrategy} with a valid cache time of 20s

--- a/src/main/java/io/github/hypixel_api_wrapper/http/cache/BasicCachingStrategy.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/cache/BasicCachingStrategy.java
@@ -2,7 +2,7 @@ package io.github.hypixel_api_wrapper.http.cache;
 
 import io.github.hypixel_api_wrapper.http.Endpoint;
 import java.time.Clock;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.Pair;
 import org.json.JSONObject;


### PR DESCRIPTION
Changed `HashMap` to an `EnumMap` in class `BasicCachingStrategy`

Unsure of its real benefits, but it is recommended to be used in scenarios where the `key` value of the `HashMap` is meant to be an enum.