### PR TITLE
Removed unnecessary checks on #equals() method

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/http/query/PlayerFriendsQuery.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/query/PlayerFriendsQuery.java
@@ -38,10 +38,6 @@ public class PlayerFriendsQuery extends Query {
     public boolean equals(Object o) {
         PlayerFriendsQuery other = (PlayerFriendsQuery) o;
 
-        if (o == this) {
-            return true;
-        }
-
         if(uuid != null) {
             return other.getUUID().equals(uuid);
         }

--- a/src/main/java/io/github/hypixel_api_wrapper/http/query/PlayerQuery.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/query/PlayerQuery.java
@@ -39,10 +39,6 @@ public class PlayerQuery extends Query {
     public boolean equals(Object o) {
         PlayerQuery other = (PlayerQuery) o;
 
-        if (o == this) {
-            return true;
-        }
-
         if(uuid != null) {
             return other.getUUID().equals(uuid);
         }

--- a/src/main/java/io/github/hypixel_api_wrapper/http/query/PlayerRecentGamesQuery.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/query/PlayerRecentGamesQuery.java
@@ -38,9 +38,6 @@ public class PlayerRecentGamesQuery extends Query {
     public boolean equals(Object o) {
         PlayerRecentGamesQuery other = (PlayerRecentGamesQuery) o;
 
-        if (o == this) {
-            return true;
-        }
 
         if(uuid != null) {
             return other.getUUID().equals(uuid);

--- a/src/main/java/io/github/hypixel_api_wrapper/http/query/PlayerStatusQuery.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/query/PlayerStatusQuery.java
@@ -38,10 +38,6 @@ public class PlayerStatusQuery extends Query {
     public boolean equals(Object o) {
         PlayerStatusQuery other = (PlayerStatusQuery) o;
 
-        if (o == this) {
-            return true;
-        }
-
         if(uuid != null) {
             return other.getUUID().equals(uuid);
         }


### PR DESCRIPTION
Since the `UUID` or `Username` is being checked, there is no need for the #equals() method to check if the object being compared is the same object that it is.