### PR TITLE
Make RequestFactory non asynchronous

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
@@ -41,17 +41,10 @@ public class RequestFactory {
             .url(requestBuilder.build().toString())
             .build();
 
-        Call call = client.newCall(request);
-        call.enqueue(new Callback() {
-            public void onResponse(Call call, Response response)
-                throws IOException {
-                res[0] = new JSONObject(response.body().toString());
-            }
-
-            public void onFailure(Call call, IOException e) {
-                // TODO failure
-            }
-        });
-        return res[0];
+        try {
+            return new JSONObject(client.newCall(request).execute().body().string());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
When the `RequestFactory` #send() method was asynchronous it would break the program. That is because the wrapper would try to call a `JSONObject` before the `JSONObject` was set, except it could do that because it was asynchronous.

The program would terminate with a `NullPointerException`.