### PR TITLE
Instantiate guild with UUID

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/Test.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/Test.java
@@ -1,0 +1,13 @@
+package io.github.hypixel_api_wrapper;
+
+import io.github.hypixel_api_wrapper.HypixelAPI;
+import io.github.hypixel_api_wrapper.wrapper.player.HypixelPlayer;
+import java.util.UUID;
+
+public class Test {
+    public static void main(String[] args) {
+        HypixelAPI api = HypixelAPI.create(UUID.fromString("d8e7f0b1-6dcf-4a96-993c-8f11cf2fe15b"));
+        HypixelPlayer player = api.getPlayerByName("sk1er");
+        System.out.println(player.getNetworkKarma());
+    }
+}

--- a/src/main/java/io/github/hypixel_api_wrapper/http/RequestController.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/RequestController.java
@@ -54,4 +54,14 @@ public class RequestController {
         Query query = queryFactory.getPlayerStatus(username);
         return requestFactory.send(query.createRequest());
     }
+
+    public JSONObject getGuild(UUID uuid) {
+        Query query = queryFactory.getGuild(uuid);
+        return requestFactory.send(query.createRequest());
+    }
+
+    public JSONObject getGuild(String username) {
+        Query query = queryFactory.getGuild(username);
+        return requestFactory.send(query.createRequest());
+    }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/http/query/GuildQuery.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/query/GuildQuery.java
@@ -1,0 +1,47 @@
+package io.github.hypixel_api_wrapper.http.query;
+
+import io.github.hypixel_api_wrapper.http.Endpoint;
+import java.util.UUID;
+import okhttp3.HttpUrl;
+
+public class GuildQuery extends Query {
+    private String name;
+    private UUID uuid;
+
+    protected GuildQuery(String name) {
+        this.name = name;
+    }
+
+    protected GuildQuery(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    @Override
+    public HttpUrl.Builder createRequest() {
+        if(uuid != null ) {
+            return HttpUrl.get(Endpoint.PLAYER.getURL()).newBuilder()
+                .addQueryParameter("uuid", uuid.toString());
+        }
+        return HttpUrl.get(Endpoint.PLAYER.getURL()).newBuilder()
+            .addQueryParameter("name", name);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public UUID getUUID() {
+        return uuid;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        GuildQuery other = (GuildQuery) o;
+
+        if(uuid != null) {
+            return other.getUUID().equals(uuid);
+        }
+
+        return other.getName().equals(name);
+    }
+}

--- a/src/main/java/io/github/hypixel_api_wrapper/http/query/QueryFactory.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/query/QueryFactory.java
@@ -35,4 +35,12 @@ public class QueryFactory {
         return new PlayerStatusQuery(username);
     }
 
+    public Query getGuild(UUID uuid) {
+        return new GuildQuery(uuid);
+    }
+
+    public Query getGuild(String username) {
+        return new GuildQuery(username);
+    }
+
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/guild/HypixelGuild.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/guild/HypixelGuild.java
@@ -4,19 +4,25 @@ import io.github.hypixel_api_wrapper.http.RequestController;
 import io.github.hypixel_api_wrapper.http.RequestFactory;
 import io.github.hypixel_api_wrapper.wrapper.player.HypixelPlayer;
 import java.util.List;
+import java.util.UUID;
+import org.json.JSONObject;
 
 public class HypixelGuild {
+    private final RequestController requestController;
+    private final JSONObject guildStats;
 
-    private final String name;
-    private final RequestController requestFactory;
+    public HypixelGuild(String name, RequestController requestController) {
+        this.requestController = requestController;
+        this.guildStats = requestController.getGuild(name);
+    }
 
-    public HypixelGuild(String name, RequestController requestFactory) {
-        this.name = name;
-        this.requestFactory = requestFactory;
+    public HypixelGuild(UUID uuid, RequestController requestController) {
+        this.requestController = requestController;
+        this.guildStats = requestController.getGuild(uuid);
     }
 
     public String getName() {
-        return name;
+        return throw new UnsupportedOperationException();
     }
 
     public double getLevel() {

--- a/src/main/java/io/github/hypixel_api_wrapper/wrapper/guild/HypixelGuild.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/wrapper/guild/HypixelGuild.java
@@ -22,7 +22,7 @@ public class HypixelGuild {
     }
 
     public String getName() {
-        return throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException();
     }
 
     public double getLevel() {


### PR DESCRIPTION
Overload the `HypixelGuild` constructor to accept a `UUID` so it can be instantiated through a `HypixelPlayer`.