### PR TITLE
Exception handling

### DIFF
--- a/src/main/java/io/github/hypixel_api_wrapper/exception/ForbiddenAccessException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/ForbiddenAccessException.java
@@ -1,0 +1,8 @@
+package io.github.hypixel_api_wrapper.exception;
+
+public class ForbiddenAccessException extends NovopixelException {
+
+    public ForbiddenAccessException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/ForbiddenAccessException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/ForbiddenAccessException.java
@@ -1,5 +1,8 @@
 package io.github.hypixel_api_wrapper.exception;
 
+/**
+ * Access is forbidden, usually due to an invalid API key being used.
+ */
 public class ForbiddenAccessException extends NovopixelException {
 
     public ForbiddenAccessException(String message) {

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/GuildNotFoundException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/GuildNotFoundException.java
@@ -1,5 +1,8 @@
 package io.github.hypixel_api_wrapper.exception;
 
+/**
+ * A guild is not found in the API.
+ */
 public class GuildNotFoundException extends NovopixelException {
 
     public GuildNotFoundException(String message) {

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/GuildNotFoundException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/GuildNotFoundException.java
@@ -1,6 +1,6 @@
 package io.github.hypixel_api_wrapper.exception;
 
-public class GuildNotFoundException extends PineappleException {
+public class GuildNotFoundException extends NovopixelException {
 
     public GuildNotFoundException(String message) {
         super(message);

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/InvalidAPIKeyException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/InvalidAPIKeyException.java
@@ -1,8 +1,0 @@
-package io.github.hypixel_api_wrapper.exception;
-
-public class InvalidAPIKeyException extends NovopixelException {
-
-    public InvalidAPIKeyException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/InvalidAPIKeyException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/InvalidAPIKeyException.java
@@ -1,6 +1,6 @@
 package io.github.hypixel_api_wrapper.exception;
 
-public class InvalidAPIKeyException extends PineappleException {
+public class InvalidAPIKeyException extends NovopixelException {
 
     public InvalidAPIKeyException(String message) {
         super(message);

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/InvalidDataException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/InvalidDataException.java
@@ -1,0 +1,8 @@
+package io.github.hypixel_api_wrapper.exception;
+
+public class InvalidDataException extends NovopixelException {
+
+    public InvalidDataException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/InvalidDataException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/InvalidDataException.java
@@ -1,5 +1,8 @@
 package io.github.hypixel_api_wrapper.exception;
 
+/**
+ * Some data provided is invalid.
+ */
 public class InvalidDataException extends NovopixelException {
 
     public InvalidDataException(String message) {

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/KeyThrottleException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/KeyThrottleException.java
@@ -1,6 +1,6 @@
 package io.github.hypixel_api_wrapper.exception;
 
-public class KeyThrottleException extends PineappleException {
+public class KeyThrottleException extends NovopixelException {
 
     public KeyThrottleException(String message) {
         super(message);

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/KeyThrottleException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/KeyThrottleException.java
@@ -1,5 +1,9 @@
 package io.github.hypixel_api_wrapper.exception;
 
+/**
+ * A request limit has been reached, usually this is due to the limit on the key being reached but
+ * can also be triggered by a global throttle.
+ */
 public class KeyThrottleException extends NovopixelException {
 
     public KeyThrottleException(String message) {

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/MalformedUUIDException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/MalformedUUIDException.java
@@ -1,8 +1,0 @@
-package io.github.hypixel_api_wrapper.exception;
-
-public class MalformedUUIDException extends NovopixelException {
-
-    public MalformedUUIDException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/MalformedUUIDException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/MalformedUUIDException.java
@@ -1,6 +1,6 @@
 package io.github.hypixel_api_wrapper.exception;
 
-public class MalformedUUIDException extends PineappleException {
+public class MalformedUUIDException extends NovopixelException {
 
     public MalformedUUIDException(String message) {
         super(message);

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/MissingFieldException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/MissingFieldException.java
@@ -1,0 +1,8 @@
+package io.github.hypixel_api_wrapper.exception;
+
+public class MissingFieldException extends NovopixelException {
+
+    public MissingFieldException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/MissingFieldException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/MissingFieldException.java
@@ -1,5 +1,8 @@
 package io.github.hypixel_api_wrapper.exception;
 
+/**
+ * Some data is missing, usually a field.
+ */
 public class MissingFieldException extends NovopixelException {
 
     public MissingFieldException(String message) {

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/NovopixelException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/NovopixelException.java
@@ -15,8 +15,7 @@ public class NovopixelException extends RuntimeException {
 
     @Override
     public String toString() {
-        return "NovopixelException{" +
-            "message='" + message + '\'' +
-            '}';
+        return "NovopixelException: " +
+            "API response = '" + message + '\'';
     }
 }

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/NovopixelException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/NovopixelException.java
@@ -1,10 +1,10 @@
 package io.github.hypixel_api_wrapper.exception;
 
-public class PineappleException extends RuntimeException {
+public class NovopixelException extends RuntimeException {
 
     private final String message;
 
-    public PineappleException(String message) {
+    public NovopixelException(String message) {
         this.message = message;
     }
 
@@ -15,7 +15,7 @@ public class PineappleException extends RuntimeException {
 
     @Override
     public String toString() {
-        return "PineappleException{" +
+        return "NovopixelException{" +
             "message='" + message + '\'' +
             '}';
     }

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/PlayerNotFoundException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/PlayerNotFoundException.java
@@ -1,5 +1,8 @@
 package io.github.hypixel_api_wrapper.exception;
 
+/**
+ * A player is not found in the API.
+ */
 public class PlayerNotFoundException extends NovopixelException {
 
     public PlayerNotFoundException(String message) {

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/PlayerNotFoundException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/PlayerNotFoundException.java
@@ -1,6 +1,6 @@
 package io.github.hypixel_api_wrapper.exception;
 
-public class PlayerNotFoundException extends PineappleException {
+public class PlayerNotFoundException extends NovopixelException {
 
     public PlayerNotFoundException(String message) {
         super(message);

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/UnknownAPIException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/UnknownAPIException.java
@@ -1,5 +1,8 @@
 package io.github.hypixel_api_wrapper.exception;
 
+/**
+ * Other exceptions from the API that have not been handled.
+ */
 public class UnknownAPIException extends NovopixelException {
 
     public UnknownAPIException(String message) {

--- a/src/main/java/io/github/hypixel_api_wrapper/exception/UnknownAPIException.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/exception/UnknownAPIException.java
@@ -1,6 +1,6 @@
 package io.github.hypixel_api_wrapper.exception;
 
-public class UnknownAPIException extends PineappleException {
+public class UnknownAPIException extends NovopixelException {
 
     public UnknownAPIException(String message) {
         super(message);

--- a/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/RequestFactory.java
@@ -1,5 +1,6 @@
 package io.github.hypixel_api_wrapper.http;
 
+import io.github.hypixel_api_wrapper.exception.NovopixelException;
 import io.github.hypixel_api_wrapper.http.cache.CachingStrategy;
 import java.io.IOException;
 import java.util.UUID;
@@ -32,15 +33,19 @@ public class RequestFactory {
      * @return A {@link JSONObject} of the information retrieved.
      */
     public JSONObject send(HttpUrl.Builder requestBuilder) {
-        
+
         requestBuilder.addQueryParameter("key", apiKey);
 
         Request request = new Request.Builder()
             .url(requestBuilder.build().toString())
             .build();
 
-        try {
-            return new JSONObject(client.newCall(request).execute().body().string());
+        try (Response response = client.newCall(request).execute()) {
+            if (RequestValidator.isValid(response)) {
+                return new JSONObject(response.body().string());
+            } else {
+                throw new NovopixelException("Fatal error, invalid response not caught.");
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/io/github/hypixel_api_wrapper/http/RequestValidator.java
+++ b/src/main/java/io/github/hypixel_api_wrapper/http/RequestValidator.java
@@ -1,33 +1,48 @@
 package io.github.hypixel_api_wrapper.http;
 
+import io.github.hypixel_api_wrapper.exception.ForbiddenAccessException;
 import io.github.hypixel_api_wrapper.exception.GuildNotFoundException;
-import io.github.hypixel_api_wrapper.exception.InvalidAPIKeyException;
 import io.github.hypixel_api_wrapper.exception.KeyThrottleException;
-import io.github.hypixel_api_wrapper.exception.MalformedUUIDException;
+import io.github.hypixel_api_wrapper.exception.InvalidDataException;
+import io.github.hypixel_api_wrapper.exception.MissingFieldException;
 import io.github.hypixel_api_wrapper.exception.PlayerNotFoundException;
 import io.github.hypixel_api_wrapper.exception.UnknownAPIException;
+import java.io.IOException;
+import okhttp3.Response;
 import org.json.JSONObject;
 
 public class RequestValidator {
 
-    public static boolean isValid(JSONObject obj) {
-        if (!obj.getBoolean("success")) {
-            switch (obj.getString("cause")) {
-                case "Malformed UUID":
-                    throw new MalformedUUIDException("Invalid UUID provided.");
-                case "Invalid API key":
-                    throw new InvalidAPIKeyException("Invalid API key provided");
-                case "Key throttle":
-                    throw new KeyThrottleException("Exceeded 120 requests/minute to the API.");
-                default:
-                    throw new UnknownAPIException("An unknown error has occurred.");
+    public static boolean isValid(Response response) {
+        try {
+            JSONObject returnObject = new JSONObject(response.body().string());
+            if (response.isSuccessful()) {
+                if (returnObject.isNull("player")) {
+                    throw new PlayerNotFoundException("Player not found.");
+                } else if (returnObject.isNull("guild")) {
+                    throw new GuildNotFoundException("Guild not found.");
+                } else {
+                    return true;
+                }
+            } else {
+                String failString = returnObject.getString("cause");
+
+                switch (response.code()) {
+                    case 400:
+                        throw new MissingFieldException(failString);
+                    case 403:
+                        throw new ForbiddenAccessException(failString);
+                    case 422:
+                        throw new InvalidDataException(failString);
+                    case 429:
+                        throw new KeyThrottleException(failString);
+                    default:
+                        throw new UnknownAPIException(failString);
+                }
             }
-        } else if (obj.isNull("player")) {
-            throw new PlayerNotFoundException("Player not found.");
-        } else if (obj.isNull("guild")) {
-            throw new GuildNotFoundException("Guild not found.");
-        } else {
-            return true;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 }
+


### PR DESCRIPTION
- Handle all exceptions from the API.
- Automatically handle and provide unique exceptions for codes 400, 403, 422 and 429.
- Handle `PlayerNotFoundException` and `GuildNotFoundException` exceptions.
- Default to `UnknownAPIException` if the exception is unknown. 
- If all else fails, throw a generic `NovopixelException`. 
